### PR TITLE
Feature/nodedge style refactor

### DIFF
--- a/.github/workflows/describe-pr.yml
+++ b/.github/workflows/describe-pr.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   describe:
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/describe-pr.yml
+++ b/.github/workflows/describe-pr.yml
@@ -7,17 +7,19 @@ on:
     branches:
       - main
 
-steps:
-- uses: actions/checkout@v3
+jobs:
+  describe:
+    steps:
+    - uses: actions/checkout@v3
 
-- uses: octue/generate-pull-request-description@1.0.0.beta-2
-  id: pr-description
-  with:
-    pull_request_url: ${{ github.event.pull_request.url }}
-    api_token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: octue/generate-pull-request-description@1.0.0.beta-2
+      id: pr-description
+      with:
+        pull_request_url: ${{ github.event.pull_request.url }}
+        api_token: ${{ secrets.GITHUB_TOKEN }}
 
-- name: Update pull request body
-  uses: riskledger/update-pr-description@v2
-  with:
-    body: ${{ steps.pr-description.outputs.pull_request_description }}
-    token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Update pull request body
+      uses: riskledger/update-pr-description@v2
+      with:
+        body: ${{ steps.pr-description.outputs.pull_request_description }}
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@
 # separate terms of service, privacy policy, and support
 # documentation.
 
-name: Upload Python Package to Pypi
+name: Publish Python Package on Pypi
 
 on:
   release:
@@ -16,7 +16,7 @@ permissions:
   contents: read
 
 jobs:
-  deploy:
+  publish:
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -16,7 +16,7 @@ on:
 #    - cron: '30 1 * * 0'
 
 jobs:
-  CodeQL-Build:
+  scan:
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ on:
     types: [opened, synchronize]
 
 jobs:
-  build:
+  test:
     runs-on: ${{ matrix.platform }}
     strategy:
       matrix:

--- a/logging.yaml
+++ b/logging.yaml
@@ -70,7 +70,7 @@ root:
 
 loggers:
     nodedge.node:
-        handlers: [stdout, debug_file_handler]
+        handlers: [debug_file_handler]
 #        handlers: [stdout, info]
 
     nodedge.logger:
@@ -109,6 +109,6 @@ loggers:
         propagate: false
 
     nodedge.graphics_scene:
-        handlers: [stdout, debug_file_handler]
+        handlers: [debug_file_handler]
         level: DEBUG
         propagate: false

--- a/logging.yaml
+++ b/logging.yaml
@@ -70,7 +70,7 @@ root:
 
 loggers:
     nodedge.node:
-        handlers: [debug_file_handler]
+        handlers: [stdout, debug_file_handler]
 #        handlers: [stdout, info]
 
     nodedge.logger:
@@ -109,6 +109,6 @@ loggers:
         propagate: false
 
     nodedge.graphics_scene:
-        handlers: [debug_file_handler]
+        handlers: [stdout, debug_file_handler]
         level: DEBUG
         propagate: false

--- a/nodedge/graphics_edge.py
+++ b/nodedge/graphics_edge.py
@@ -9,7 +9,7 @@ Graphics edge module containing :class:`~nodedge.graphics_edge.GraphicsEdge`,
 
 import logging
 import math
-from typing import List, Optional, Union, cast
+from typing import List, Optional, Union
 
 from PySide6.QtCore import QPointF, Qt
 from PySide6.QtGui import QColor, QPainterPath, QPen
@@ -140,7 +140,7 @@ class GraphicsEdge(QGraphicsPathItem):
 
         self._penDragging: QPen = QPen(self._color)
         self._penDragging.setWidthF(2.0)
-        self._penDragging.setStyle(Qt.DashLine)
+        # self._penDragging.setStyle(Qt.DashLine)
 
         self.setZValue(-1)
 

--- a/nodedge/graphics_node.py
+++ b/nodedge/graphics_node.py
@@ -71,7 +71,7 @@ class GraphicsNode(QGraphicsItem):
     @title.setter
     def title(self, value):
         self._title = value
-        self.titleLabel.setText(self._title)
+        self.titleLabel.setText(self._title.lower())
 
     @property
     def type(self):
@@ -171,7 +171,7 @@ class GraphicsNode(QGraphicsItem):
             titleLayout = QHBoxLayout()
             titleLayout.setContentsMargins(0, 0, 0, 0)
             titleFrame.setLayout(titleLayout)
-            self.titleLabel = GraphicsNodeTitleLabel(self.title, widget)
+            self.titleLabel = GraphicsNodeTitleLabel(self.title.lower(), widget)
             self.titleLabel.setSizePolicy(
                 QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
             )

--- a/nodedge/graphics_scene.py
+++ b/nodedge/graphics_scene.py
@@ -142,10 +142,11 @@ class GraphicsScene(QGraphicsScene):
         logger.debug(f"item: {item}")
 
         if not event.modifiers() & Qt.ShiftModifier:
-            for item in self.selectedItems():
-                if item is not None:
-                    item.setSelected(False)
-            self.itemsDeselected.emit()
+            self.scene.doDeselectItems(silent=True)
+            # for item in self.selectedItems():
+            #     if item is not None:
+            #         item.setSelected(False)
+            # self.itemsDeselected.emit()
 
         if (
             item is not None
@@ -158,10 +159,11 @@ class GraphicsScene(QGraphicsScene):
 
         if item is not None:
             item.setSelected(True)
-        logger.debug(f"Selected items in graphics scene: {self.selectedItems()}")
 
         super().mousePressEvent(event)
         self.itemSelected.emit()
+        logger.debug(f"Selected items in graphics scene: {self.selectedItems()}")
+        logger.debug(f"Last selected item: {self.scene.lastSelectedItems}")
 
     def mouseReleaseEvent(self, event: QGraphicsSceneMouseEvent) -> None:
         """
@@ -177,6 +179,8 @@ class GraphicsScene(QGraphicsScene):
             # item.setSelected(True)
 
         super().mouseReleaseEvent(event)
+
+        logger.debug(f"Last selected item: {self.scene.lastSelectedItems}")
 
     def mouseMoveEvent(self, event: QGraphicsSceneMouseEvent) -> None:
         self.mouseMoved.emit(event.scenePos())

--- a/nodedge/graphics_scene.py
+++ b/nodedge/graphics_scene.py
@@ -141,6 +141,12 @@ class GraphicsScene(QGraphicsScene):
         item: Optional[QGraphicsItem] = self.itemAt(event.scenePos(), QTransform())
         logger.debug(f"item: {item}")
 
+        if not event.modifiers() & Qt.ShiftModifier:
+            for item in self.selectedItems():
+                if item is not None:
+                    item.setSelected(False)
+            self.itemsDeselected.emit()
+
         if (
             item is not None
             and item not in self.selectedItems()
@@ -149,13 +155,13 @@ class GraphicsScene(QGraphicsScene):
         ):
             logger.debug(f"Pressed item: {item}")
             logger.debug(f"Pressed parent item: {item.parentItem()}")
-            logger.debug(f"Selected items in graphics scene: {self.selectedItems()}")
-            for item in self.selectedItems():
-                if item is not None:
-                    item.setSelected(False)
 
-        self.itemSelected.emit()
+        if item is not None:
+            item.setSelected(True)
+        logger.debug(f"Selected items in graphics scene: {self.selectedItems()}")
+
         super().mousePressEvent(event)
+        self.itemSelected.emit()
 
     def mouseReleaseEvent(self, event: QGraphicsSceneMouseEvent) -> None:
         """
@@ -167,7 +173,8 @@ class GraphicsScene(QGraphicsScene):
         item = self.itemAt(event.scenePos(), QTransform())
 
         if item is not None:
-            item.setSelected(True)
+            pass
+            # item.setSelected(True)
 
         super().mouseReleaseEvent(event)
 

--- a/nodedge/mdi_widget.py
+++ b/nodedge/mdi_widget.py
@@ -94,11 +94,17 @@ class MdiWidget(EditorWidget):
         keys = list(BLOCKS.keys())
         keys.sort()
         menus = {}
+        libraries = []
+        for key in keys:
+            node = getClassFromOperationCode(key)
+            libraries.append(node.library)
+        for library in sorted(libraries):
+            contextMenu.addMenu(self.libraryMenus[library])
+
         for key in keys:
             node = getClassFromOperationCode(key)
             library = node.library
             if library not in menus.keys():
-                contextMenu.addMenu(self.libraryMenus[library])
                 menus[library] = self.libraryMenus[library]
             else:
                 menu = menus[library]

--- a/nodedge/nodedge_app_window.py
+++ b/nodedge/nodedge_app_window.py
@@ -82,7 +82,7 @@ class NodedgeAppWindow(QMainWindow):
             lambda: self.mainWidget.setCurrentWidget(self.homepageWindow)
         )
 
-        self.datsWindow.homeMenu.aboutToShow.connect(
+        self.datsWindow.homeMenu.pressed.connect(
             lambda: self.mainWidget.setCurrentWidget(self.homepageWindow)
         )
         self.mainWidget.setCurrentIndex(0)

--- a/nodedge/scene.py
+++ b/nodedge/scene.py
@@ -178,9 +178,12 @@ class Scene(Serializable):
             return
 
         selectedItems = self.selectedItems
-        if selectedItems != self._lastSelectedItems:
-            self.lastSelectedItems = selectedItems
+        logger.debug(f"Selected items in scene: {selectedItems}")
+        logger.debug(f"Last selected items in scene: {self._lastSelectedItems}")
 
+        if self.selectedItems != self._lastSelectedItems:
+            if selectedItems:
+                self.lastSelectedItems = self.selectedItems
             if not silent:
                 # we could create some kind of UI which could be serialized,
                 # therefore first run all callbacks...

--- a/tests/scene_test.py
+++ b/tests/scene_test.py
@@ -201,7 +201,7 @@ def test_onSelectedItems(qtbot: QtBot):
     window.setActiveSubWindow(subWindow)
 
     pos2 = editorWidget.scene.graphicsView.mapToScene(QPoint(-10, -10))
-    pos3 = editorWidget.scene.graphicsView.mapToScene(QPoint(10, 10))
+    pos3 = editorWidget.scene.graphicsView.mapToScene(QPoint(-5, -5))
     editorWidget.scene.graphicsView.show()
 
     # editorWidget.scene.graphicsScene.setFocus(Qt.ActiveWindowFocusReason)
@@ -216,10 +216,10 @@ def test_onSelectedItems(qtbot: QtBot):
     assert scene.lastSelectedItems == [node.graphicsNode]
 
     qtbot.mousePress(
-        editorWidget, Qt.LeftButton, pos=QPoint(int(-pos3.x()), int(-pos3.y()))
+        editorWidget, Qt.LeftButton, pos=QPoint(int(pos3.x()), int(pos3.y()))
     )
     qtbot.mouseRelease(
-        editorWidget, Qt.LeftButton, pos=QPoint(int(-pos3.x()), int(-pos3.y()))
+        editorWidget, Qt.LeftButton, pos=QPoint(int(pos3.x()), int(pos3.y()))
     )
     assert scene.selectedItems == []
     assert scene.lastSelectedItems == [node.graphicsNode]


### PR DESCRIPTION
Resolves #111.
Resolves #112.
Resolves #113.
Resolves #114.
Resolves #115.
Resolves #124.
<!--- START AUTOGENERATED NOTES --->
# Contents ([#123](https://github.com/nodedge/nodedge/pull/123))

### Other
- Resolves #114. Libraries are sorted in context menu.
- Resolves #113. Block titles are lower cased.
- Resolves #111. Dragging edge is not dashed anymore.
- Resolves #115. Hovering Dats Home menu does not open homepage anymore.
- Resolves #112. Select node even if the mouse moved before button release.
- rename github actions properly.
- Last selected items was wrong.
- Add os environment on describe-pr action.

<!--- END AUTOGENERATED NOTES --->