### PR TITLE
Feat/dats close log file

### DIFF
--- a/nodedge/blocks/block.py
+++ b/nodedge/blocks/block.py
@@ -95,7 +95,8 @@ class Block(Node):
         """
         self.__logger.debug(f"New socket: {socket}")
         self.isDirty = True
-        # self.eval()
+        if self.scene.realTimeEval:
+            self.eval()
 
     def checkInputsValidity(self):
         for index in range(len(self.inputSockets)):

--- a/nodedge/console_widget.py
+++ b/nodedge/console_widget.py
@@ -127,12 +127,13 @@ class ConsoleWidget(QWidget):
                 self.execMulti(cmd)
             else:
                 p = QApplication.palette()
-                color = p.dark().color().name()
+                color = p.base().color().name()
                 textColor = p.text().color().name()
+                highlight = p.highlight().color().name()
 
                 self.write(
-                    f"<br><div style='background-color: {color}; color: {textColor}'><b>%s</b>\n"
-                    % encCmd,
+                    f"<br><span style='background-color: {color}; color: {highlight}'>>>> </span>"
+                    f"<span style='background-color: {color}; color: {textColor}'><b> {encCmd}</b>\n",
                     html=True,
                     scrollToBottom=True,
                 )
@@ -140,7 +141,7 @@ class ConsoleWidget(QWidget):
                 self.execSingle(cmd)
 
             if not self.inCmd:
-                self.write("</div>\n", html=True, scrollToBottom=True)
+                self.write("</span>", html=True, scrollToBottom=True)
 
         finally:
             sys.stdout = orig_stdout
@@ -249,11 +250,11 @@ class ConsoleWidget(QWidget):
         else:
             if self.inCmd:
                 p = QApplication.palette()
-                color = p.mid().color().name()
+                color = p.base().color().name()
                 textColor = p.text().color().name()
                 self.inCmd = False
                 self.output.textCursor().insertHtml(
-                    f"</div><br><div style='font-weight: normal; background-color: {color}; color: {textColor}'>"
+                    f"</span><br><span style='font-weight: normal; background-color: {color}; color: {textColor}'>"
                 )
             self.output.insertPlainText(strn)
 

--- a/nodedge/dats/dats_window.py
+++ b/nodedge/dats/dats_window.py
@@ -760,26 +760,27 @@ class DatsWindow(QMainWindow):
     def updateDataItems(self, log: Optional[MDF]):
         self.signalsWidget.signalsTableWidget.updateItems(log)
 
-        for curveName in self.curveConfig:
-            formula = self.curveConfig[curveName]["formula"]
-            signals = self.signalsWidget.signalsTableWidget.signals
+        if log is not None:
+            for curveName in self.curveConfig:
+                formula = self.curveConfig[curveName]["formula"]
+                signals = self.signalsWidget.signalsTableWidget.signals
 
-            newSignal = evaluateFormula(curveName, formula, signals, log)
+                newSignal = evaluateFormula(curveName, formula, signals, log)
 
-            if newSignal is None:
-                ret = QMessageBox.warning(
-                    self,
-                    "Error",
-                    f"Error evaluating formula for curve {curveName}.\n Do you want to continue computing curves?",
-                    QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
-                )
+                if newSignal is None:
+                    ret = QMessageBox.warning(
+                        self,
+                        "Error",
+                        f"Error evaluating formula for curve {curveName}.\n Do you want to continue computing curves?",
+                        QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+                    )
 
-                if ret == QMessageBox.StandardButton.No:
-                    break
-                elif ret == QMessageBox.StandardButton.Yes:
-                    continue
+                    if ret == QMessageBox.StandardButton.No:
+                        break
+                    elif ret == QMessageBox.StandardButton.Yes:
+                        continue
 
-            log.append(newSignal)
+                log.append(newSignal)
         self.signalsWidget.signalsTableWidget.updateItems(log)
         lastFoundDataItem = NPlotDataItem()
         lastFoundDataItem.setData(x=[0, 1], y=[0, 1])

--- a/nodedge/dats/dats_window.py
+++ b/nodedge/dats/dats_window.py
@@ -757,7 +757,7 @@ class DatsWindow(QMainWindow):
             )
             self.recentFilesMenu.addAction(action)
 
-    def updateDataItems(self, log):
+    def updateDataItems(self, log: Optional[MDF]):
         self.signalsWidget.signalsTableWidget.updateItems(log)
 
         for curveName in self.curveConfig:
@@ -799,8 +799,8 @@ class DatsWindow(QMainWindow):
                         worksheet.updateRange(dataItem)
                         lastFoundDataItem = dataItem
 
-                    except MdfException as mdfException:
-                        logging.warning(mdfException)
+                    except (MdfException, AttributeError) as e:
+                        logging.warning(e)
                         dataItem.setData(x=[0, 1], y=[0, 0])
                         # worksheet.updateRange(dataItem)
 

--- a/nodedge/dats/signals_list_widget.py
+++ b/nodedge/dats/signals_list_widget.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from asammdf import MDF
 from PySide6.QtWidgets import QAbstractItemView, QListWidget
 
@@ -11,7 +13,12 @@ class SignalsListWidget(QListWidget):
         self.signals = signals
         self.addItems(self.signals)
 
-    def updateList(self, log: MDF):
+    def updateList(self, log: Optional[MDF]):
+        self.clear()
+
+        if log is None:
+            return
+
         signals = list(log.channels_db.keys())
         signals = [c for c in signals if c[0:3] != "CAN"]
         signals = [c for c in signals if c[0:3] != "LIN"]
@@ -20,5 +27,4 @@ class SignalsListWidget(QListWidget):
         self.signals = signals
         self.signals = sorted(self.signals)
 
-        self.clear()
         self.addItems(self.signals)

--- a/nodedge/dats/signals_table_widget.py
+++ b/nodedge/dats/signals_table_widget.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List
+from typing import List, Optional
 
 from asammdf import MDF
 from PySide6.QtCore import QByteArray, QMimeData, Qt
@@ -54,7 +54,9 @@ class SignalsTableWidget(QTableWidget):
         if not event.modifiers() & Qt.KeyboardModifier.ControlModifier:
             self.multiSelectionMode = False
 
-    def updateItems(self, log: MDF):
+    def updateItems(self, log: Optional[MDF]):
+        self.clearContents()
+        self.setRowCount(0)
         if log is None:
             return
         signals = list(log.channels_db.keys())
@@ -73,9 +75,6 @@ class SignalsTableWidget(QTableWidget):
 
         configSignals = list(self._parent.curveConfig.keys())
         self.allSignals = sorted(list(set(self.signals + configSignals)))
-
-        self.clearContents()
-        self.setRowCount(0)
 
         for signal in self.signals:
             typeItem = QTableWidgetItem()

--- a/nodedge/editor_widget.py
+++ b/nodedge/editor_widget.py
@@ -201,7 +201,8 @@ class EditorWidget(QWidget):
             # Don't store initial stamp because the file has still not been changed.
             self.scene.history.clear()
             QApplication.restoreOverrideCursor()
-            # self.evalNodes()
+            if self.scene.realTimeEval:
+                self.evalNodes()
             self.scene.resetAllNodes()
             return True
         except FileNotFoundError as e:

--- a/nodedge/editor_window.py
+++ b/nodedge/editor_window.py
@@ -329,6 +329,24 @@ class EditorWindow(QMainWindow):
             category="Help",
         )
 
+        self.realTimeEvalAct = self.createAction(
+            "Real-time evaluation",
+            self.onRealTimeEval,
+            "Evaluate model in real time",
+            QKeySequence("Ctrl+Shift+A"),
+            category="Simulator",
+        )
+        self.realTimeEvalAct.setCheckable(True)
+        self.realTimeEvalAct.setIcon(QIcon("resources/lucide/alarm-check.svg"))
+
+    def onRealTimeEval(self, checked: bool) -> None:
+        """
+        Enable/disable real-time evaluation.
+        """
+        self.currentEditorWidget.scene.realTimeEval = checked
+        if checked:
+            self.currentEditorWidget.evalNodes()
+
     def onHelp(self):
         pass
 

--- a/nodedge/editor_window.py
+++ b/nodedge/editor_window.py
@@ -343,6 +343,10 @@ class EditorWindow(QMainWindow):
         """
         Enable/disable real-time evaluation.
         """
+        if self.currentEditorWidget is None:
+            return
+        if hasattr(self.currentEditorWidget, "scene") is False:
+            return
         self.currentEditorWidget.scene.realTimeEval = checked
         if checked:
             self.currentEditorWidget.evalNodes()

--- a/nodedge/editor_window.py
+++ b/nodedge/editor_window.py
@@ -390,15 +390,16 @@ class EditorWindow(QMainWindow):
         totalSteps = self.currentEditorWidget.scene.simulator.totalSteps
         finalTime = self.currentEditorWidget.scene.simulator.config.finalTime
         currentTime = self.currentEditorWidget.scene.simulator.currentTimeStep
+        currentStep = self.currentEditorWidget.scene.simulator.currentStep
         stepsPerSecond = self.currentEditorWidget.scene.simulator.stepsPerSecond
         percentPerSecond = stepsPerSecond / totalSteps * 100
-        percentProgress = progress / totalSteps * 100
+        percentProgress = currentStep / totalSteps * 100
         self.simulationProgressBar.setValue(int(percentProgress))
         self.simulationProgressLabel.setText(
-            f"Progress: {currentTime:.1E} s/{finalTime} s [{percentProgress:.1E}%] [{percentPerSecond:.0E} %/s]"
+            f"Progress: {currentTime:.1E} s/{finalTime:.1E} s [{percentProgress:.0f}%] [{percentPerSecond:.0E} %/s]"
         )
         self.simulationProgressLabel.setToolTip(
-            f"{progress:.0E}/{totalSteps:.0E} [{percentProgress:.0E}]% [{stepsPerSecond:.0E} steps/s]"
+            f"{currentStep:.0E}/{totalSteps:.0E} [{percentProgress:.0E}]% [{stepsPerSecond:.0E} steps/s]"
         )
 
     def onShowGraph(self):

--- a/nodedge/editor_window.py
+++ b/nodedge/editor_window.py
@@ -440,6 +440,9 @@ class EditorWindow(QMainWindow):
         self.coderMenu.addAction(self.showCodeAct)
 
     def configureSolver(self):
+        if self.currentEditorWidget is None:
+            QMessageBox.warning(self, "No model", "No model is open.")
+            return
         simulatorConfig = self.currentEditorWidget.scene.simulator.config
         self.solverDialog = SolverDialog(simulatorConfig)
         self.solverDialog.solverConfigChanged.connect(

--- a/nodedge/graphics_cut_line.py
+++ b/nodedge/graphics_cut_line.py
@@ -58,7 +58,7 @@ class CutLine:
             if (
                 eventType == QEvent.MouseButtonPress
                 and eventButton == Qt.LeftButton
-                and eventModifiers & Qt.ControlModifier
+                and eventModifiers & Qt.AltModifier
             ):
 
                 self.mode = CutLineMode.CUTTING
@@ -96,6 +96,7 @@ class CutLine:
         try:
             scene: "Scene" = self.graphicsView.graphicsScene.scene  # type: ignore
             self.__logger.debug(f"Cutting points: {self.graphicsCutLine.linePoints}")
+            atLeastOneEdge = False
             for ix in range(len(self.graphicsCutLine.linePoints) - 1):
                 p1 = self.graphicsCutLine.linePoints[ix]
                 p2 = self.graphicsCutLine.linePoints[ix + 1]
@@ -112,13 +113,16 @@ class CutLine:
                             f"[{p1.__pos__()}, {p2.__pos__()}] intersects with: {edge}"
                         )
                         edge.remove()
+                        atLeastOneEdge = True
                     else:
                         self.__logger.debug(
                             f"[{p1.__pos__()}, {p2.__pos__()}] does not intersect with: "
                             f"{edge.graphicsEdge.path()}"
                         )
 
-            scene.history.store("Delete edges.")
+            if atLeastOneEdge:
+                scene.history.store("Delete edge(s).")
+
             self.__logger.debug("Cutting has been done.")
 
         except Exception as e:

--- a/nodedge/homepage/left_menu_widget.py
+++ b/nodedge/homepage/left_menu_widget.py
@@ -54,6 +54,7 @@ class LeftMenuWidget(QFrame):
         self.anim.setStartValue(self.closedWidth)
         self.anim.setEndValue(self.openWidth)
         self.setFixedWidth(0)
+        self.setMinimumWidth(0)
 
         self.open = False
 

--- a/nodedge/homepage/main_widget.py
+++ b/nodedge/homepage/main_widget.py
@@ -19,6 +19,7 @@ class MainWidget(QWidget):
         self.mainBodyFrame = MainBodyFrame()
         self.layout.addWidget(self.headerFrame)
         self.layout.addWidget(self.mainBodyFrame)
+        self.mainBodyFrame.leftMenuWidget.toggle()
 
         self.headerFrame.menuButton.clicked.connect(self.updateLeftMenu)
 

--- a/nodedge/mdi_window.py
+++ b/nodedge/mdi_window.py
@@ -105,7 +105,7 @@ class MdiWindow(EditorWindow):
         self.createSceneItemDetailDock()
         self.createNodesDock()
         self.createHistoryDock()
-        self.createSceneItemsDock()
+        # self.createSceneItemsDock()
         self.createSceneItemsTreeDock()
         self.createPythonConsole()
 
@@ -268,8 +268,10 @@ class MdiWindow(EditorWindow):
         self.toolBars.append(self.coderToolBar)
 
         self.simuToolbar = QToolBar("Simulation")
-        self.addToolBar(Qt.ToolBarArea.BottomToolBarArea, self.simuToolbar)
+        self.addToolBar(self.simuToolbar)
         self.simuToolbar.setMovable(True)
+        self.simuToolbar.addAction(self.realTimeEvalAct)
+        self.simuToolbar.addSeparator()
         self.simuToolbar.addAction(self.startSimulationAct)
         self.simuToolbar.addAction(self.pauseSimulationAct)
         self.simuToolbar.addAction(self.stopSimulationAct)
@@ -446,9 +448,9 @@ class MdiWindow(EditorWindow):
         subWindow.setWindowIcon(icon)
         editor.scene.history.addHistoryModifiedListener(self.updateEditMenu)
         editor.scene.history.addHistoryModifiedListener(self.historyListWidget.update)
-        editor.scene.history.addHistoryModifiedListener(
-            self.sceneItemsTableWidget.update
-        )
+        # editor.scene.history.addHistoryModifiedListener(
+        #     self.sceneItemsTableWidget.update
+        # )
         editor.scene.addItemsDeselectedListener(self.sceneItemDetailsWidget.update)
         editor.scene.addItemSelectedListener(self.sceneItemDetailsWidget.update)
         editor.addCloseEventListener(self.onSubWindowClosed)
@@ -469,9 +471,9 @@ class MdiWindow(EditorWindow):
             return
 
         self.mdiArea.setActiveSubWindow(subWindowToBeDeleted)
-        self.sceneItemsTableWidget.scene = None
+        # self.sceneItemsTableWidget.scene = None
         self.sceneItemsTreeWidget.scene = None
-        self.sceneItemsTableWidget.clearContents()
+        # self.sceneItemsTableWidget.clearContents()
 
         if self.maybeSave():
             event.accept()
@@ -687,7 +689,7 @@ class MdiWindow(EditorWindow):
                         editor.updateTitle()
                         subWindow = self._createMdiSubWindow(editor)
                         subWindow.show()
-                        self.sceneItemsTableWidget.update()
+                        # self.sceneItemsTableWidget.update()
                         self.sceneItemsTreeWidget.update()
                     else:
                         logger.debug("Loading fail")
@@ -697,7 +699,7 @@ class MdiWindow(EditorWindow):
                 editor.newFile()
                 subWindow = self._createMdiSubWindow(editor)
                 subWindow.show()
-                self.sceneItemsTableWidget.update()
+                # self.sceneItemsTableWidget.update()
                 self.sceneItemsTreeWidget.update()
 
     def about(self) -> None:
@@ -752,7 +754,7 @@ class MdiWindow(EditorWindow):
 
         if self.currentEditorWidget is not None:
             self.historyListWidget.history = self.currentEditorWidget.scene.history
-            self.sceneItemsTableWidget.scene = self.currentEditorWidget.scene
+            # self.sceneItemsTableWidget.scene = self.currentEditorWidget.scene
             self.sceneItemsTreeWidget.scene = self.currentEditorWidget.scene
             graphicsScene = self.currentEditorWidget.scene.graphicsScene
             graphicsScene.itemsPressed.connect(self.showItemsInStatusBar)

--- a/nodedge/mdi_window.py
+++ b/nodedge/mdi_window.py
@@ -261,15 +261,15 @@ class MdiWindow(EditorWindow):
         self.editToolBar.addAction(self.addCommentElementAct)
         self.editToolBar.addSeparator()
         self.toolBars.append(self.editToolBar)
-
-        self.coderToolBar = self.addToolBar("Coder")
-        self.coderToolBar.setMovable(False)
-        self.coderToolBar.addAction(self.generateCodeAct)
-        self.toolBars.append(self.coderToolBar)
+        #
+        # self.coderToolBar = self.addToolBar("Coder")
+        # self.coderToolBar.setMovable(False)
+        # self.coderToolBar.addAction(self.generateCodeAct)
+        # self.toolBars.append(self.coderToolBar)
 
         self.simuToolbar = QToolBar("Simulation")
         self.addToolBar(self.simuToolbar)
-        self.simuToolbar.setMovable(True)
+        self.simuToolbar.setMovable(False)
         self.simuToolbar.addAction(self.realTimeEvalAct)
         self.simuToolbar.addSeparator()
         self.simuToolbar.addAction(self.startSimulationAct)

--- a/nodedge/node_tree_widget.py
+++ b/nodedge/node_tree_widget.py
@@ -52,6 +52,7 @@ class NodeTreeWidget(QTreeWidget):
         self.setSortingEnabled(True)
         self.setHeaderLabels(list(COLUMNS.keys()))
         self.sortByColumn(0, Qt.AscendingOrder)
+        self.setIndentation(6)
 
     # noinspection PyAttributeOutsideInit
     def initUI(self) -> None:

--- a/nodedge/scene.py
+++ b/nodedge/scene.py
@@ -79,6 +79,8 @@ class Scene(Serializable):
         # current filename assigned to this scene
         self.filename: Optional[str] = None
 
+        self.realTimeEval = False
+
     @property
     def shortName(self) -> str:
         """

--- a/nodedge/scene_items_tree_widget.py
+++ b/nodedge/scene_items_tree_widget.py
@@ -42,6 +42,8 @@ class SceneItemsTreeWidget(QTreeWidget):
         self.itemClicked.connect(self.onItemClicked)
         self.itemDoubleClicked.connect(self.onItemDoubleClicked)
 
+        self.setIndentation(6)
+
     @property
     def scene(self) -> Optional[Scene]:
         return self._scene

--- a/nodedge/solver_dialog.py
+++ b/nodedge/solver_dialog.py
@@ -41,7 +41,7 @@ class SolverDialog(QDialog):
         self.configLayout = QFormLayout()
         self.configFrame.setLayout(self.configLayout)
         self.solverCombo = QComboBox()
-        self.solverCombo.addItems(["No Solver", "Solver2", "Solver3"])
+        self.solverCombo.addItems(["Basic solver"])
         self.solverCombo.currentIndexChanged.connect(self.updateSolverConfig)
 
         self.solverOptions = QLineEdit()
@@ -51,9 +51,9 @@ class SolverDialog(QDialog):
         self.toleranceSpinBox = QDoubleSpinBox()
         self.finalTimeEdit = QLineEdit()
 
-        self.configLayout.addRow("Solver Name", self.solverName)
+        self.configLayout.addRow("Solver name", self.solverName)
         self.configLayout.addRow("Solver", self.solverCombo)
-        self.configLayout.addRow("Solver Options", self.solverOptions)
+        self.configLayout.addRow("Solver options", self.solverOptions)
         self.configLayout.addRow("Time step", self.timestepSpinBox)
         self.configLayout.addRow("Max iterations", self.maxIterationsSpinBox)
         self.configLayout.addRow("Tolerance", self.toleranceSpinBox)

--- a/nodedge/solver_dialog.py
+++ b/nodedge/solver_dialog.py
@@ -28,10 +28,11 @@ class SolverDialog(QDialog):
         self.setWindowIcon(self.icon)
         self.setWindowFlags(Qt.WindowCloseButtonHint | Qt.WindowMinimizeButtonHint)
         self.setWindowModality(Qt.ApplicationModal)
-        # self.setFixedSize(400, 300)
         self.initUI()
         self.solverConfiguration = solverConfig
         self.updateUIFromConfig()
+
+        self.setFixedWidth(400)
 
     def initUI(self):
         self.mainLayout = QVBoxLayout()

--- a/resources/qss/nodedge_style.qss
+++ b/resources/qss/nodedge_style.qss
@@ -686,3 +686,7 @@ LinkButton:pressed:focus {
     background-color: palette(base);
     color: palette(highlight);
 }
+
+QToolButton:checked {
+    background: palette(highlight);
+}


### PR DESCRIPTION
<!--- START AUTOGENERATED NOTES --->
# Contents ([#165](https://github.com/nodedge/nodedge/pull/165))

### Uncategorised!
- Resolves #154. Reduce indent in tree widgets.
- Resolves #150. Add context menu when a log is clicked in the log list.
- Fix mypy.
- Resolves #169. base background in console and prepend >>> before command.
- Remove unused solver options.
- Resolves #170. Resize solver dialog and add warning if no model is open.
- Resolves #168 and resolves #167. Add new action for real time evaluation.
- Resolves #166. Homepage menu is open at the start of the app.
- Resolves #162. Store edge deletion event in history only if at least one edge has been cut.
- Fix simulation progressbar.
- Fix mypy.

<!--- END AUTOGENERATED NOTES --->